### PR TITLE
Fix keyboard controller jest mock export

### DIFF
--- a/jest/index.js
+++ b/jest/index.js
@@ -42,6 +42,21 @@ const state = {
   isVisible: false,
 };
 
+const DefaultKeyboardToolbarTheme = {
+  light: {
+    primary: "#2c2c2c",
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
+    ripple: "#bcbcbcbc",
+  },
+  dark: {
+    primary: "#fafafa",
+    disabled: "#707070",
+    background: "#2C2C2E",
+    ripple: "#F8F8F888",
+  },
+};
+
 const mock = {
   // hooks
   /// keyboard
@@ -105,6 +120,8 @@ const mock = {
   KeyboardAvoidingView: View,
   KeyboardAwareScrollView: ScrollView,
   KeyboardToolbar: View,
+  // themes
+  DefaultKeyboardToolbarTheme,
 };
 
 module.exports = mock;


### PR DESCRIPTION
## 📜 Description

Adds `DefaultKeyboardToolbarTheme` to the Jest mock to prevent test failures when components access keyboard toolbar theme properties.

## 💡 Motivation and Context

This change addresses the issue where `DefaultKeyboardToolbarTheme` was not exported by the `react-native-keyboard-controller/jest` mock, leading to `TypeError: Cannot read properties of undefined (reading 'dark')` in Jest tests. By including this export, developers no longer need to create custom mocks, significantly improving the testing experience for components that customize keyboard toolbar themes.

## 📢 Changelog

### JS

- Export `DefaultKeyboardToolbarTheme` in Jest mock.

### iOS

-

### Android

-

## 🤔 How Has This Been Tested?

The fix was verified by following the reproduction steps outlined in the issue description. A test case that imports and uses `DefaultKeyboardToolbarTheme` from the mock now passes without errors. The exported theme structure in the mock accurately reflects the actual `DefaultKeyboardToolbarTheme` implementation in the library.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed

---
<a href="https://cursor.com/background-agent?bcId=bc-d893b564-b769-4b3c-b5e0-a6ada689a96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d893b564-b769-4b3c-b5e0-a6ada689a96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a default Keyboard Toolbar theme to the testing mocks, including light and dark variants with standardized color tokens.
  * Enables theme-aware test scenarios and improves consistency when simulating UI states across themes.
  * Reduces flakiness in visual and interaction tests by providing stable, predictable theme values.
  * Facilitates broader test coverage for components relying on theme-driven styling and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->